### PR TITLE
feat: Adds environment variable controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,11 +237,11 @@ The `CODEBLOCK_START` HTML comment config block has the following properties:
 | Name          | Type                  | Required | Default                                             | Description                                                    |
 | ------------- | --------------------- | -------- | --------------------------------------------------- | -------------------------------------------------------------- |
 | `value`       | `string`              | `true`   |                                                     | Command to execute or file to retrieve                         |
-| `type`        | `'command' \| 'file'` | `false`  | `'file'`                                            | Type of execution                                              |
-| `language`    | `string`              | `false`  | `command`:&nbsp;`bash`, `file`:&nbsp;File extension | Syntax highlighting language                                   |
-| `hideValue`   | `boolean`             | `false`  | `false`                                             | Do not display `File: foo.js` or `$ npx foo` on the first line |
-| `trim`        | `boolean`             | `false`  | `true`                                              | Trim whitespace from the ends of file or command output        |
 | `environment` | `object`              | `false`  | `{}`                                                | Run `command` executions with the given environment values     |
+| `hideValue`   | `boolean`             | `false`  | `false`                                             | Do not display `File: foo.js` or `$ npx foo` on the first line |
+| `language`    | `string`              | `false`  | `command`:&nbsp;`bash`, `file`:&nbsp;File extension | Syntax highlighting language                                   |
+| `trim`        | `boolean`             | `false`  | `true`                                              | Trim whitespace from the ends of file or command output        |
+| `type`        | `'command' \| 'file'` | `false`  | `'file'`                                            | Type of execution                                              |
 
 ## Contributing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,11 @@ program
     'prevents globs from following symlinks'
   )
   .option('-Q --quiet', 'emits no console log statements', false)
+  .option(
+    '-E --no-system-environment',
+    'prevents "command"s from receiving system environment',
+    false
+  )
   .description('Add file or command output to markdown documents.')
   .usage(
     `[options] <glob pattern>
@@ -37,6 +42,7 @@ Examples:
       followSymbolicLinks: options.followSymbolicLinks,
       globPattern,
       quiet: options.quiet,
+      systemEnvironment: options.systemEnvironment,
     })
   })
 

--- a/src/md-inject.ts
+++ b/src/md-inject.ts
@@ -9,9 +9,10 @@ enum BlockSourceType {
   command = 'command',
 }
 
-interface BlockOptions {
+export interface BlockOptions {
   value: string
   hideValue?: boolean
+  environment?: NodeJS.ProcessEnv
   ignore?: boolean
   language?: string
   trim?: boolean
@@ -27,14 +28,22 @@ interface ReplaceOptions {
   followSymbolicLinks: boolean
   globPattern: string
   quiet: boolean
+  systemEnvironment: boolean
 }
 
 const main = async (
-  { blockPrefix, followSymbolicLinks, globPattern, quiet }: ReplaceOptions = {
+  {
+    blockPrefix,
+    followSymbolicLinks,
+    globPattern,
+    quiet,
+    systemEnvironment,
+  }: ReplaceOptions = {
     blockPrefix: 'CODEBLOCK',
     followSymbolicLinks: true,
     globPattern: '**/*.md',
     quiet: false,
+    systemEnvironment: true,
   }
 ): Promise<void> => {
   const logger = new Logger(quiet)
@@ -93,6 +102,7 @@ const main = async (
         hideValue = false,
         trim = true,
         ignore = false,
+        environment = {},
       } = config
 
       if (ignore) {
@@ -117,7 +127,7 @@ const main = async (
           out = await new Promise((resolve, reject) => {
             exec(
               value,
-              { env: { ...process.env, FORCE_COLOR: '0' } },
+              { env: prepareEnvironment(environment, systemEnvironment) },
               (err, stdout) => {
                 if (err) {
                   return reject(err)
@@ -238,6 +248,29 @@ ${endPragma}`
     process.exitCode = 1
   }
   logger.groupEnd()
+}
+
+const prepareEnvironment = (
+  providedEnvironment: NodeJS.ProcessEnv,
+  useSystemEnvironment: boolean
+) => {
+  const systemEnvironment = useSystemEnvironment ? process.env : {}
+  providedEnvironment = Object.entries(providedEnvironment)
+    .map(([key, value]) => {
+      const valueEnvMatch = /^\$(\w+)$/.exec(value)
+      if (valueEnvMatch) {
+        const envKey = valueEnvMatch[1]
+        value = process.env[envKey]
+      }
+      return [key, value]
+    })
+    .reduce((agg, [k, v]) => ({ ...agg, [k]: v }), {})
+
+  return {
+    ...systemEnvironment,
+    FORCE_COLOR: '0',
+    ...providedEnvironment,
+  }
 }
 
 export default main


### PR DESCRIPTION
closes #2 

# Features

## `environment` property for `command` `CODEBLOCK`s

Specific environment can now be applied to a `command` `CODEBLOCK`'s `exec` call. This can be handy for situations where scripts require or must emulate an environment the user is in so they may execute properly. For example, some scripts will fail when the git history is dirty unless provided with an environment variable to bypass. Given we're in the process of writing markdown files, a dirty git history while `markdown-inject` is running is almost guaranteed.

Additionally, `environment` keys with a complete value that matches bash variable syntax (ex: `$FOO`) will be replaced with a value from `process.env`. This can be handy for if you decide to use...... ⬇️ 

## `--no-system-environment` CLI flag

Some users (opensource maintainers?) may want to shield their environment or have tighter control over what the environment is. `--no-system-environment` will prevent `process.env` from being passed into all command executions.

# Validation

I've added unit tests to assert the various ways environment values overwrite each other. I encourage you (the reviewer) to view the new `README.md` section on `Environment` and try out the changes.