### PR TITLE
fix(ci): upgrade later workflow steps to same cache version

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,7 +43,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Load Deployment
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         env:
           cache-name: deployment-cache
         with:
@@ -62,7 +62,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Load Deployment
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         env:
           cache-name: deployment-cache
         with:


### PR DESCRIPTION
<!--
Thanks for being here!
Review these resources before making a contribution:
  - Code of Conduct: https://github.com/target/markdown-inject/blob/main/CODE_OF_CONDUCT.md
  - Contribution guide: https://github.com/target/markdown-inject/blob/main/CONTRIBUTING.md
-->

See warnings within the recent publication https://github.com/target/markdown-inject/actions/runs/3744386278

# Changes

More workflow upgrades. I missed these in the initial analysis of the workflow, since they didn't run! 

# Validation

N/A