### PR TITLE
build: add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -125,6 +125,11 @@ updates:
       timezone: "Asia/Kolkata"
     allow:
       - dependency-type: "direct"
+    groups:
+      eslint-and-prettier:
+        patterns:
+          - "*eslint*"
+          - "*prettier*"
 
   - package-ecosystem: "nuget"
     directory: "/"


### PR DESCRIPTION
Experimenting with https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/

Would help us resolve all of these at once
![image](https://github.com/target/markdown-inject/assets/298435/a8b5f2df-a96c-4f09-9512-0f7bf053119f)
